### PR TITLE
fix: unknown language crash

### DIFF
--- a/src/Codeblock.tsx
+++ b/src/Codeblock.tsx
@@ -35,12 +35,13 @@ function resolveLang(id: string) {
 }
 
 export default function (props: { lang: string; code: string }): JSX.Element {
-  const { lang, code } = props;
+  const { code } = props;
+  const lang = props.lang.toLowerCase();
 
   let lines;
-  let langName = resolveLang(lang);
-  if (langName) {
-    const res = highlight(lang.toLowerCase(), code);
+  const langName = resolveLang(lang);
+  if (hljs.getLanguage(lang)) {
+    const res = highlight(lang, code);
     lines = res.value
       .split("\n")
       .map((line) => <span dangerouslySetInnerHTML={{ __html: line }}></span>);


### PR DESCRIPTION
Closes #4, and https://discord.com/channels/1000926524452647132/1159284741464412161

Ensures that hljs can highlight (threw an error before since it doesn't have all languages from langs.json)

Also works with different cases now (\`\`\`hTmL)